### PR TITLE
Add country Cymru a.k.a. Wales

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phonelib"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Mohamad Al Zohbie <alzoubi528@gmail.com>"]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,7 +2,7 @@ use crate::definitions;
 
 use definitions::Country;
 
-pub const COUNTRIES: [Country; 246] = [
+pub const COUNTRIES: [Country; 247] = [
     Country {
         name: "Andorra",
         code: "AD",
@@ -338,6 +338,12 @@ pub const COUNTRIES: [Country; 246] = [
         code: "CY",
         phone_lengths: &[8],
         prefix: 357,
+    },
+    Country {
+        name: "Cymru",
+        code: "GB-CYM",
+        phone_lengths: &[10],
+        prefix: 44,
     },
     Country {
         name: "Czech Republic",

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,12 +1,11 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        extract_country, is_valid_phone_number, normalize_phone_number,
-        normalize_phone_number_in_place, format_phone_number, PhoneFormat,
-        detect_phone_number_type, PhoneNumberType, is_mobile_number,
-        is_landline_number, is_toll_free_number, generate_random_phone_number,
-        are_phone_numbers_equal, validate_phone_numbers_batch,
-        suggest_phone_number_corrections, is_potentially_valid_phone_number,
+        are_phone_numbers_equal, detect_phone_number_type, extract_country, format_phone_number,
+        generate_random_phone_number, is_landline_number, is_mobile_number,
+        is_potentially_valid_phone_number, is_toll_free_number, is_valid_phone_number,
+        normalize_phone_number, normalize_phone_number_in_place, suggest_phone_number_corrections,
+        validate_phone_numbers_batch, PhoneFormat, PhoneNumberType,
     };
 
     struct PhoneNumber {
@@ -14,7 +13,7 @@ mod tests {
         phone_number: &'static str,
     }
 
-    const PHONE_NUMBERS: [PhoneNumber; 211] = [
+    const PHONE_NUMBERS: [PhoneNumber; 212] = [
         PhoneNumber {
             country_code: "US",
             phone_number: "+12025550173",
@@ -858,7 +857,11 @@ mod tests {
         PhoneNumber {
             country_code: "MZ",
             phone_number: "+258821234567",
-        }, // Mozambique
+        }, // Mozambiquez
+        PhoneNumber {
+            country_code: "GB-CYM",
+            phone_number: "+442079460958",
+        }, // Great Britain - Cymru
     ];
 
     #[test]
@@ -950,7 +953,6 @@ mod tests {
             (String::from("+43 6642428349"), true),
             (String::from("+32 4706460538"), true),
             (String::from("+420 601139706"), true),
-
         ];
 
         for (phone, valid) in test_cases {
@@ -962,19 +964,19 @@ mod tests {
     #[test]
     fn test_phone_number_formatting() {
         let number = "+12345678901".to_string();
-        
+
         // Test E.164 format
         let e164 = format_phone_number(number.clone(), PhoneFormat::E164);
         assert_eq!(e164, Some("+12345678901".to_string()));
-        
+
         // Test International format
         let intl = format_phone_number(number.clone(), PhoneFormat::International);
         assert!(intl.is_some());
-        
+
         // Test National format
         let national = format_phone_number(number.clone(), PhoneFormat::National);
         assert!(national.is_some());
-        
+
         // Test RFC3966 format
         let rfc = format_phone_number(number.clone(), PhoneFormat::RFC3966);
         assert!(rfc.is_some());
@@ -985,11 +987,11 @@ mod tests {
         // Test US toll-free number
         let toll_free = is_toll_free_number("18001234567".to_string());
         assert!(toll_free || !is_valid_phone_number("18001234567".to_string()));
-        
+
         // Test mobile detection function
         let mobile_result = is_mobile_number("447123456789".to_string());
         assert!(mobile_result || !is_valid_phone_number("447123456789".to_string()));
-        
+
         // Test landline detection function
         let landline_result = is_landline_number("12025551234".to_string());
         assert!(landline_result || !is_valid_phone_number("12025551234".to_string()));
@@ -1001,12 +1003,12 @@ mod tests {
         if let Some(number) = random_us {
             assert!(is_valid_phone_number(number));
         }
-        
+
         let random_gb = generate_random_phone_number("GB");
         if let Some(number) = random_gb {
             assert!(is_valid_phone_number(number));
         }
-        
+
         // Test invalid country code
         let invalid = generate_random_phone_number("XX");
         assert!(invalid.is_none());
@@ -1017,7 +1019,7 @@ mod tests {
         let num1 = "+12345678901".to_string();
         let num2 = "12345678901".to_string();
         let num3 = "+12345678902".to_string();
-        
+
         assert!(are_phone_numbers_equal(num1.clone(), num2));
         assert!(!are_phone_numbers_equal(num1, num3));
     }
@@ -1029,10 +1031,10 @@ mod tests {
             "invalid".to_string(),
             "+442079460958".to_string(),
         ];
-        
+
         let results = validate_phone_numbers_batch(numbers.clone());
         assert_eq!(results.len(), 3);
-        
+
         // First and third should be valid, second should be invalid
         assert!(results[0]);
         assert!(!results[1]);
@@ -1043,11 +1045,11 @@ mod tests {
     fn test_phone_number_suggestions() {
         let suggestions = suggest_phone_number_corrections("123456789".to_string(), Some("US"));
         assert!(!suggestions.is_empty());
-        
+
         // Test potentially valid check
         let potentially_valid = is_potentially_valid_phone_number("123-456-7890".to_string());
         assert!(potentially_valid);
-        
+
         let not_valid = is_potentially_valid_phone_number("123".to_string());
         assert!(!not_valid);
     }
@@ -1058,7 +1060,7 @@ mod tests {
         let phone_type = detect_phone_number_type("447123456789".to_string());
         // Should be Some(Mobile) or None if invalid
         assert!(phone_type.is_some() || !is_valid_phone_number("447123456789".to_string()));
-        
+
         if let Some(ptype) = phone_type {
             assert!(ptype == PhoneNumberType::Mobile || ptype == PhoneNumberType::Unknown);
         }
@@ -1071,10 +1073,10 @@ mod tests {
     #[test]
     fn test_extract_phone_numbers_from_text() {
         use crate::extract_phone_numbers_from_text;
-        
+
         let text = "Call me at +12025550173 or +442079460958 for support.";
         let numbers = extract_phone_numbers_from_text(text);
-        
+
         assert_eq!(numbers.len(), 2);
         assert!(numbers[0].raw.contains("12025550173"));
         assert!(numbers[1].raw.contains("442079460958"));
@@ -1083,10 +1085,10 @@ mod tests {
     #[test]
     fn test_extract_phone_with_various_formats() {
         use crate::extract_phone_numbers_from_text;
-        
+
         let text = "Numbers: (202) 555-0173, 202.555.0174, 202-555-0175";
         let numbers = extract_phone_numbers_from_text(text);
-        
+
         // Should find multiple number patterns
         assert!(!numbers.is_empty());
     }
@@ -1094,10 +1096,10 @@ mod tests {
     #[test]
     fn test_extract_valid_phone_numbers_only() {
         use crate::extract_valid_phone_numbers_from_text;
-        
+
         let text = "Valid: +12025550173, Invalid: 123";
         let numbers = extract_valid_phone_numbers_from_text(text);
-        
+
         // Should only return valid numbers
         for num in &numbers {
             assert!(num.is_valid);
@@ -1107,10 +1109,10 @@ mod tests {
     #[test]
     fn test_extract_with_country_hint() {
         use crate::extract_phone_numbers_with_country_hint;
-        
+
         let text = "Call (202) 555-0173";
         let numbers = extract_phone_numbers_with_country_hint(text, "US");
-        
+
         assert!(!numbers.is_empty());
         // With US hint, national number should be recognized
     }
@@ -1118,20 +1120,20 @@ mod tests {
     #[test]
     fn test_count_phone_numbers() {
         use crate::count_phone_numbers_in_text;
-        
+
         let text = "Contact: +12025550173, +442079460958";
         let count = count_phone_numbers_in_text(text);
-        
+
         assert_eq!(count, 2);
     }
 
     #[test]
     fn test_replace_phone_numbers() {
         use crate::replace_phone_numbers_in_text;
-        
+
         let text = "Call +12025550173 today!";
         let replaced = replace_phone_numbers_in_text(text, |_| "[PHONE]".to_string());
-        
+
         assert!(replaced.contains("[PHONE]"));
         assert!(!replaced.contains("12025550173"));
     }
@@ -1139,10 +1141,10 @@ mod tests {
     #[test]
     fn test_redact_phone_numbers() {
         use crate::redact_phone_numbers;
-        
+
         let text = "Call +12025550173";
         let redacted = redact_phone_numbers(text, 4);
-        
+
         // Should have stars and visible digits
         assert!(redacted.contains("*") || redacted.contains("[PHONE]"));
     }
@@ -1150,10 +1152,10 @@ mod tests {
     #[test]
     fn test_extract_positions() {
         use crate::extract_phone_numbers_from_text;
-        
+
         let text = "Phone: +12025550173";
         let numbers = extract_phone_numbers_from_text(text);
-        
+
         if !numbers.is_empty() {
             let num = &numbers[0];
             // Verify positions make sense
@@ -1169,10 +1171,10 @@ mod tests {
     #[test]
     fn test_phone_number_struct_parse() {
         use crate::PhoneNumber as PhoneNum;
-        
+
         let phone = PhoneNum::parse("+12025550173");
         assert!(phone.is_some());
-        
+
         let phone = phone.unwrap();
         assert_eq!(phone.e164(), "+12025550173");
     }
@@ -1180,11 +1182,11 @@ mod tests {
     #[test]
     fn test_phone_number_equality_trait() {
         use crate::PhoneNumber as PhoneNum;
-        
+
         let num1 = PhoneNum::parse("+12025550173").unwrap();
         let num2 = PhoneNum::parse("12025550173").unwrap();
         let num3 = PhoneNum::parse("+442079460958").unwrap();
-        
+
         // Same number, different formats should be equal
         assert_eq!(num1, num2);
         // Different numbers should not be equal
@@ -1195,25 +1197,25 @@ mod tests {
     fn test_phone_number_hash() {
         use crate::PhoneNumber as PhoneNum;
         use std::collections::HashSet;
-        
+
         let mut set = HashSet::new();
-        
+
         let num1 = PhoneNum::parse("+12025550173").unwrap();
         let num2 = PhoneNum::parse("12025550173").unwrap();
-        
+
         set.insert(num1);
         set.insert(num2); // Should not add duplicate
-        
+
         assert_eq!(set.len(), 1);
     }
 
     #[test]
     fn test_phone_number_with_country_hint() {
         use crate::PhoneNumber as PhoneNum;
-        
+
         // National number with country hint
         let phone = PhoneNum::parse_with_country("2025550173", "US");
-        
+
         if let Some(p) = phone {
             assert!(p.e164().starts_with("+1"));
         }
@@ -1222,10 +1224,10 @@ mod tests {
     #[test]
     fn test_phone_number_national_number() {
         use crate::PhoneNumber as PhoneNum;
-        
+
         let phone = PhoneNum::parse("+12025550173").unwrap();
         let national = phone.national_number();
-        
+
         // National number should not include country code
         assert!(!national.starts_with("+"));
         assert!(!national.starts_with("1") || national.len() < 11);
@@ -1233,11 +1235,11 @@ mod tests {
 
     #[test]
     fn test_phone_number_format_method() {
-        use crate::PhoneNumber as PhoneNum;
         use crate::PhoneFormat;
-        
+        use crate::PhoneNumber as PhoneNum;
+
         let phone = PhoneNum::parse("+12025550173").unwrap();
-        
+
         let e164 = phone.format(PhoneFormat::E164);
         assert!(e164.starts_with("+"));
     }
@@ -1245,20 +1247,20 @@ mod tests {
     #[test]
     fn test_phone_number_display() {
         use crate::PhoneNumber as PhoneNum;
-        
+
         let phone = PhoneNum::parse("+12025550173").unwrap();
         let display = format!("{}", phone);
-        
+
         assert_eq!(display, "+12025550173");
     }
 
     #[test]
     fn test_phone_number_from_str() {
         use crate::PhoneNumber as PhoneNum;
-        
+
         let phone: Result<PhoneNum, _> = "+12025550173".parse();
         assert!(phone.is_ok());
-        
+
         let invalid: Result<PhoneNum, _> = "invalid".parse();
         assert!(invalid.is_err());
     }
@@ -1270,22 +1272,22 @@ mod tests {
     #[test]
     fn test_phone_number_set_basic() {
         use crate::PhoneNumberSet;
-        
+
         let mut set = PhoneNumberSet::new();
-        
+
         assert!(set.add("+12025550173"));
         assert!(!set.add("12025550173")); // Duplicate
-        
+
         assert_eq!(set.len(), 1);
     }
 
     #[test]
     fn test_phone_number_set_contains() {
         use crate::PhoneNumberSet;
-        
+
         let mut set = PhoneNumberSet::new();
         set.add("+12025550173");
-        
+
         assert!(set.contains("+12025550173"));
         assert!(set.contains("12025550173")); // Same number, different format
         assert!(!set.contains("+442079460958"));
@@ -1294,10 +1296,10 @@ mod tests {
     #[test]
     fn test_phone_number_set_remove() {
         use crate::PhoneNumberSet;
-        
+
         let mut set = PhoneNumberSet::new();
         set.add("+12025550173");
-        
+
         assert!(set.remove("12025550173")); // Remove using different format
         assert!(set.is_empty());
     }
@@ -1305,21 +1307,21 @@ mod tests {
     #[test]
     fn test_phone_number_set_from_iterator() {
         use crate::PhoneNumberSet;
-        
+
         let numbers = vec!["+12025550173", "12025550173", "+442079460958"];
         let set: PhoneNumberSet = numbers.into_iter().collect();
-        
+
         assert_eq!(set.len(), 2); // First two are duplicates
     }
 
     #[test]
     fn test_phone_number_set_iter() {
         use crate::PhoneNumberSet;
-        
+
         let mut set = PhoneNumberSet::new();
         set.add("+12025550173");
         set.add("+442079460958");
-        
+
         let count = set.iter().count();
         assert_eq!(count, 2);
     }
@@ -1327,7 +1329,7 @@ mod tests {
     #[test]
     fn test_phone_number_type_checks() {
         use crate::PhoneNumber as PhoneNum;
-        
+
         // These tests depend on the type detection logic
         let phone = PhoneNum::parse("+18005551234"); // US toll-free pattern
         if let Some(p) = phone {


### PR DESCRIPTION
Add the country Cymru, which is also known as Wales. Cymru is currently in the United Kingdom and uses the same +44 prefix and same phone number length. The Cymru country code is currently GB-CYM in Great Britain. 

This pull request enables phonelib to correctly handle phone numbers that are in a multiple-language internationalized-localized system, that uses the country name Cymru instead of United Kingdom.

Thank you for your work <3